### PR TITLE
Run latest MOI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           version: '1'
       - name: Test
-        run: julia -e 'const PACKAGE = ENV["PACKAGE"]; using Pkg; Pkg.add(PackageSpec(name="MathOptInterface", rev="release-0.9")); Pkg.develop(PACKAGE); Pkg.test(PACKAGE)'
+        run: julia -e 'const PACKAGE = ENV["PACKAGE"]; using Pkg; Pkg.add(PackageSpec(name="MathOptInterface", rev="master")); Pkg.develop(PACKAGE); Pkg.test(PACKAGE)'
   test_xpress:
     name: Xpress
     runs-on: windows-latest
@@ -70,7 +70,7 @@ jobs:
           SECRET_XPRS_WIN_8110: ${{ secrets.XPRS_WIN_8110 }}
           SECRET_XPRL_WIN_8110: ${{ secrets.XPRL_WIN_8110 }}
           SECRET_XPRA_WIN_8110: ${{ secrets.XPRA_WIN_8110 }}
-        run: julia -e 'using Pkg; Pkg.add(PackageSpec(name="MathOptInterface", rev="release-0.9")); Pkg.develop(\"Xpress\"); Pkg.test(\"Xpress\")'
+        run: julia -e 'using Pkg; Pkg.add(PackageSpec(name="MathOptInterface", rev="master")); Pkg.develop(\"Xpress\"); Pkg.test(\"Xpress\")'
   test_cplex:
     name: CPLEX
     runs-on: ubuntu-latest
@@ -84,4 +84,4 @@ jobs:
           CPLEX_VERSION: '2010'
           SECRET_CPLEX_URL_12100: ${{ secrets.SECRET_CPLEX_URL_12100 }}
           SECRET_CPLEX_URL_2010: ${{ secrets.SECRET_CPLEX_URL_2010 }}
-        run: julia -e 'using Pkg; Pkg.add(PackageSpec(name="MathOptInterface", rev="release-0.9")); Pkg.develop("CPLEX"); Pkg.test("CPLEX")'
+        run: julia -e 'using Pkg; Pkg.add(PackageSpec(name="MathOptInterface", rev="master")); Pkg.develop("CPLEX"); Pkg.test("CPLEX")'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           SECRET_XPRS_WIN_8110: ${{ secrets.XPRS_WIN_8110 }}
           SECRET_XPRL_WIN_8110: ${{ secrets.XPRL_WIN_8110 }}
           SECRET_XPRA_WIN_8130: ${{ secrets.XPRA_WIN_8130 }}
-        run: julia -e 'using Pkg; Pkg.add(PackageSpec(name="MathOptInterface", rev="master")); Pkg.develop(\"Xpress\"); Pkg.test(\"Xpress\")'
+        run: julia -e 'using Pkg; Pkg.add(PackageSpec(name=\"MathOptInterface\", rev=\"master\")); Pkg.develop(\"Xpress\"); Pkg.test(\"Xpress\")'
   test_cplex:
     name: CPLEX
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           SECRET_XPRS_WIN_8110: ${{ secrets.XPRS_WIN_8110 }}
           SECRET_XPRL_WIN_8110: ${{ secrets.XPRL_WIN_8110 }}
-          SECRET_XPRA_WIN_8110: ${{ secrets.XPRA_WIN_8130 }}
+          SECRET_XPRA_WIN_8130: ${{ secrets.XPRA_WIN_8130 }}
         run: julia -e 'using Pkg; Pkg.add(PackageSpec(name="MathOptInterface", rev="master")); Pkg.develop(\"Xpress\"); Pkg.test(\"Xpress\")'
   test_cplex:
     name: CPLEX

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - package: 'CDDLib'
           - package: 'COSMO'
           - package: 'CSDP'
-          - package: 'DSDP'
+          # - package: 'DSDP'  Unreleased package?
           - package: 'EAGO' # require gfortran
           - package: 'ECOS'
           - package: 'GLPK'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           SECRET_XPRS_WIN_8110: ${{ secrets.XPRS_WIN_8110 }}
           SECRET_XPRL_WIN_8110: ${{ secrets.XPRL_WIN_8110 }}
-          SECRET_XPRA_WIN_8110: ${{ secrets.XPRA_WIN_8110 }}
+          SECRET_XPRA_WIN_8110: ${{ secrets.XPRA_WIN_8130 }}
         run: julia -e 'using Pkg; Pkg.add(PackageSpec(name="MathOptInterface", rev="master")); Pkg.develop(\"Xpress\"); Pkg.test(\"Xpress\")'
   test_cplex:
     name: CPLEX


### PR DESCRIPTION
I just want to see the impact of this

## No support for MOI 0.10

- [x] SumOfSquares
- [ ] Alpine
- [ ] CDDLib
- [ ] COSMO
- [ ] EAGO
- [x] Hypatia
- [ ] ProxSDP
- [ ] SDPAFamily

## Caching issue https://github.com/jump-dev/MathOptInterface.jl/pull/1685

- [x] Clp
- [x] SCS
- [x] Tulip

## MOI.SolverVersion

 - [ ] MosekTools  https://github.com/jump-dev/MosekTools.jl/pull/79

## Tests for infeasibility certificates

- [x] ECOS
- [ ] Tulip
- [ ] CPLEX
- [ ] OSQP

## Other

- [x] CSDP # Spurious timeout
- [x] DSDP # Unreleased package. Why are we testing?
- [x] OSQP  https://github.com/osqp/OSQP.jl/pull/102
- [x] Xpress  # Fixed Windows " issue
